### PR TITLE
fix: prevent List from bubbling format property

### DIFF
--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -107,9 +107,9 @@ const TableBody: FunctionComponent<TableBodyProps> = ({
             ) : (
               data.map((item) => (
                 <Table.Row key={item.id}>
-                  {cells.map((cell, idx) => (
+                  {cells.map(({ format, ...cell }, idx) => (
                     <Table.Cell key={idx} {...cell}>
-                      {cell.format?.(item) ?? item[cell.path]}
+                      {format?.(item) ?? item[cell.path]}
                     </Table.Cell>
                   ))}
                   <ActionsCell


### PR DESCRIPTION

```console
index.js:1 Warning: Invalid value for prop `format` on <td> tag. Either remove it from the element, or pass a string or number value to keep it in the DOM. For details, see https://fb.me/react-attribute-behavior
    in td (created by TableCell)
    in TableCell (at List.tsx:111)
    in tr (created by TableRow)
    in TableRow (at List.tsx:109)
    in FirestoreCollection (created by Context.Consumer)
    in withFirestore(FirestoreCollection) (at List.tsx:99)
    in FirestorePath (at List.tsx:96)
    in tbody (created by TableBody)
    in TableBody (at List.tsx:95)
    in TableBody (at List.tsx:59)
    in table (created by Table)
    in Table (at List.tsx:57)
    in div (created by Segment)
    in Segment (at List.tsx:50)
    in List (at List.js:49)
    in EventList (created by Context.Consumer)
    in withFirestore(EventList) (created by Context.Consumer)
    in Route (at Main.js:14)
    in main (at Main.js:12)
    in Main (at LoggedApp.tsx:10)
    in div (at LoggedApp.tsx:8)
    in Router (created by BrowserRouter)
    in BrowserRouter (at LoggedApp.tsx:7)
    in Unknown (at App.js:44)
    in App (at src/index.js:15)
    in FirestoreProvider (at src/index.js:14)
```